### PR TITLE
lockdown of rack-test gem ...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'vcard', '~> 0.2'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'rack-test', '0.7.0'
+
+  
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 
   # Use parallel_tests to run specs across all CPU cores locally


### PR DESCRIPTION
lockdown of rack-test gem to v. 0.7.0 because of breaking change of 0.8.0 with FactoryBot