### PR TITLE
[WEBDEV-434] Refactor <a> tags to link_to() functions

### DIFF
--- a/app/views/constituencies/_former_seat_incumbencies.html.haml
+++ b/app/views/constituencies/_former_seat_incumbencies.html.haml
@@ -6,5 +6,5 @@
         - if !seat_incumbency.current?
           %li
             .list--details
-              %h3= link_to seat_incumbency.member.display_name, person_path(seat_incumbency.member.graph_id)
+              %h3= link_to(seat_incumbency.member.display_name, person_path(seat_incumbency.member.graph_id))
               %p= seat_incumbency.date_range

--- a/app/views/constituencies/_member_info.html.haml
+++ b/app/views/constituencies/_member_info.html.haml
@@ -2,14 +2,14 @@
   %li.image__item
     - if Pugin::Feature::Bandiera.show_list_images?
       %figure
-        %a{ href: "#{person_path(@current_incumbency.member.graph_id)}", tabindex: "-1" }
+        = link_to(person_path(@current_incumbency.member.graph_id), {tabindex: "-1"}) do
           - if @current_incumbency.member.image_id(show_placeholder:false)
             %img{ src: "#{ENV['IMAGE_SERVICE_URL']}/#{@current_incumbency.member.image_id}.jpg?crop=CU_1:1&width=186&quality=80", alt: "#{@current_incumbency.member.display_name}" }
           - else
             %img{ src: "#{Pugin::ASSET_LOCATION_URL}/#{Pugin::ASSET_VERSION}/images/placeholder_members_image.png", alt: "placeholder" }
 
     .list--details
-      %h2= link_to @current_incumbency.member.display_name, person_path(@current_incumbency.member.graph_id)
+      %h2= link_to(@current_incumbency.member.display_name, person_path(@current_incumbency.member.graph_id))
       %p= "#{t('people.show.mp_for')} #{@constituency.name}"
       - unless @party.nil?
         %p= @party.name

--- a/app/views/constituencies/show.html.haml
+++ b/app/views/constituencies/show.html.haml
@@ -4,7 +4,7 @@
     - @constituency.regions.each do |region|
       %p.lead
         = t('.constituency_in')
-        = link_to "#{region.name}", places_show_path(region.gss_code)
+        = link_to(region.name, places_show_path(region.gss_code))
     = render 'shared/map'
 
 = render 'constituencies/constituency'

--- a/app/views/parliaments/houses/parties/show.html.haml
+++ b/app/views/parliaments/houses/parties/show.html.haml
@@ -3,11 +3,11 @@
   .container
     %h1
       %span= @party.name
-      = link_to "#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id)
+      = link_to("#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id))
 
 %section#content{:tabindex => "0"}
   .container
     %ul.list--block
       %li
         .list--details
-          %h2= link_to "#{t('mp_plural')}", parliament_house_party_members_path(@parliament.graph_id, @house.graph_id, @party.graph_id)
+          %h2= link_to(t('mp_plural'), parliament_house_party_members_path(@parliament.graph_id, @house.graph_id, @party.graph_id))

--- a/app/views/parliaments/houses/show.html.haml
+++ b/app/views/parliaments/houses/show.html.haml
@@ -3,14 +3,14 @@
   .container
     %h1
       %span= @house.name
-      = link_to "#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id)
+      = link_to("#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id))
 
 %section#content{:tabindex => "0"}
   .container
     %ul.list--block
       %li
         .list--details
-          %h2= link_to "#{t('mp_plural')}", parliament_house_members_path(@parliament.graph_id, @house.graph_id)
+          %h2= link_to(t('mp_plural'), parliament_house_members_path(@parliament.graph_id, @house.graph_id))
       %li
         .list--details
-          %h2= link_to "#{t('party_plural').capitalize}", parliament_house_parties_path(@parliament.graph_id, @house.graph_id)
+          %h2= link_to(t('party_plural').capitalize, parliament_house_parties_path(@parliament.graph_id, @house.graph_id))

--- a/app/views/parliaments/parties/show.html.haml
+++ b/app/views/parliaments/parties/show.html.haml
@@ -3,10 +3,10 @@
   .container
     %h1
       %span= @party.name
-      = link_to "#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id)
+      = link_to("#{@parliament.date_range(date_format: '%Y')} #{t('parliament')}", parliament_path(@parliament.graph_id))
 %section#content{:tabindex => "0"}
   .container
     %ul.list--block
       %li
         .list--details
-          %h2= link_to "#{t('mp_plural')}", parliament_party_members_path(@parliament.graph_id, @party.graph_id)
+          %h2= link_to(t('mp_plural'), parliament_party_members_path(@parliament.graph_id, @party.graph_id))

--- a/app/views/parliaments/show.html.haml
+++ b/app/views/parliaments/show.html.haml
@@ -11,10 +11,10 @@
     %ul.list--block
       %li
         .list--details
-          %h2= link_to "#{t('mp_plural')}", parliament_members_path(@parliament.graph_id)
+          %h2= link_to(t('mp_plural'), parliament_members_path(@parliament.graph_id))
       %li
         .list--details
-          %h2= link_to "#{t('party_plural').capitalize}", parliament_parties_path(@parliament.graph_id)
+          %h2= link_to(t('party_plural').capitalize, parliament_parties_path(@parliament.graph_id))
       %li
         .list--details
-          %h2= link_to "#{t('constituency_plural').capitalize}", parliament_constituencies_path(@parliament.graph_id)
+          %h2= link_to(t('constituency_plural').capitalize, parliament_constituencies_path(@parliament.graph_id))

--- a/app/views/people/_contact_details.html.haml
+++ b/app/views/people/_contact_details.html.haml
@@ -7,11 +7,11 @@
         - if contact_point.email.present?
           %dt= t('contact_points.email').capitalize + ": "
           %dd
-            %a{ href: "mailto:#{contact_point.email}" }= contact_point.email
+            = link_to(contact_point.email, "mailto:#{contact_point.email}")
         - if contact_point.phone_number.present?
           %dt= t('contact_points.phone').capitalize + ": "
           %dd
-            %a{ href: "tel:#{contact_point.phone_number.gsub(/\s+/, "")}" }= contact_point.phone_number.gsub(/\s+/, " ")
+            = link_to(contact_point.phone_number.gsub(/\s+/, " "), "tel:#{contact_point.phone_number.gsub(/\s+/, "")}")
         - if contact_point.postal_addresses.present?
           %dt
             = t('contact_points.address').capitalize + ": "

--- a/app/views/people/_current_roles.html.haml
+++ b/app/views/people/_current_roles.html.haml
@@ -5,12 +5,12 @@
   - current_roles.fetch('SeatIncumbency', []).each do |role|
     - if role.class == GroupingHelper::GroupedObject
       - first_line_start = t('.mp_for')
-      - first_line_end = "#{link_to role.nodes[0].constituency.name, constituency_path(role.nodes[0].constituency.graph_id)}".html_safe
+      - first_line_end = link_to(role.nodes[0].constituency.name, constituency_path(role.nodes[0].constituency.graph_id))
       - first_line = "#{first_line_start} #{first_line_end}".html_safe
       = render 'current_role', role: role, role_type: "#{t('.parliamentary_role').capitalize}", role_title: first_line
     - else
       - first_line_start = t('.mp_for')
-      - first_line_end = "#{link_to role.constituency.name, constituency_path(role.constituency.graph_id)}".html_safe
+      - first_line_end = link_to(role.constituency.name, constituency_path(role.constituency.graph_id))
       - first_line = "#{first_line_start} #{first_line_end}".html_safe
       = render 'current_role', role: role, role_type: "#{t('.parliamentary_role').capitalize}", role_title: first_line
 

--- a/app/views/people/_image.html.haml
+++ b/app/views/people/_image.html.haml
@@ -1,5 +1,5 @@
 %figure
-  %a{ href: "#{media_show_path(@person.image_id)}" }
+  = link_to(media_show_path(@person.image_id)) do
     %picture
       %source{srcset: "#{ENV['IMAGE_SERVICE_URL']}/#{@person.image_id}.jpeg?crop=CU_5:2&width=732&quality=80, #{ENV['IMAGE_SERVICE_URL']}/#{@person.image_id}.jpeg?crop=CU_5:2&width=1464&quality=80 2x", media: "(min-width: 480px)"}
       %source{srcset: "#{ENV['IMAGE_SERVICE_URL']}/#{@person.image_id}.jpeg?crop=MCU_3:2&width=444&quality=80, #{ENV['IMAGE_SERVICE_URL']}/#{@person.image_id}.jpeg?crop=MCU_3:2&width=888&quality=80 2x"}

--- a/app/views/people/_related_links.html.haml
+++ b/app/views/people/_related_links.html.haml
@@ -10,17 +10,17 @@
               - if @person.personal_weblinks.present?
                 - @person.personal_weblinks.each do |link|
                   %dt= t('contact_points.website').capitalize + ": "
-                  %dd= link_to link, link
+                  %dd= link_to(link, link)
 
               - if @person.twitter_weblinks.present?
                 - @person.twitter_weblinks.each do |link|
                   %dt= t('contact_points.twitter').capitalize + ": "
-                  %dd= link_to link, link
+                  %dd= link_to(link, link)
 
               - if @person.facebook_weblinks.present?
                 - @person.facebook_weblinks.each do |link|
                   %dt= t('contact_points.facebook').capitalize + ": "
-                  %dd= link_to link, link
+                  %dd= link_to(link, link)
 
           - if Pugin::Feature::Bandiera.show_list_images?
             - if @person.image_id(show_placeholder:false)

--- a/app/views/people/_timeline_roles.html.haml
+++ b/app/views/people/_timeline_roles.html.haml
@@ -5,12 +5,12 @@
         - date_string = role.try(:start_date) && role.try(:end_date) ? " (#{l(role.start_date, format: :year_only)} #{t('to')} #{l(role.end_date, format: :year_only)})" : ''
         - if role.class == GroupingHelper::GroupedObject
           - role_type_start = t('.mp_for')
-          - role_type_link = "#{link_to "#{role.nodes[0].constituency.name} #{date_string}", constituency_path(role.nodes[0].constituency.graph_id)}".html_safe
+          - role_type_link = link_to("#{role.nodes[0].constituency.name} #{date_string}", constituency_path(role.nodes[0].constituency.graph_id))
           - role_type = "#{role_type_start} #{role_type_link}".html_safe
           = render 'timeline_role', role: role, role_type: role_type, role_title: "Elected #{role.nodes.count} times"
         - else
           - role_type_start = t('.mp_for')
-          - role_type_link = "#{link_to "#{role.constituency.name}#{date_string}", constituency_path(role.constituency.graph_id)}".html_safe
+          - role_type_link = link_to("#{role.constituency.name} #{date_string}", constituency_path(role.constituency.graph_id))
           - role_type = "#{role_type_start} #{role_type_link}".html_safe
           = render 'timeline_role', role: role, role_type: role_type, role_title: t('.parliamentary_role').capitalize
 

--- a/app/views/people/_when_to_contact.html.haml
+++ b/app/views/people/_when_to_contact.html.haml
@@ -1,6 +1,8 @@
 .dropdown
   .dropdown__toggle
-    %h3= link_to t('.title'), '#'
+    %h3
+      %a{ href: "#"}
+        = t('.title')
   .dropdown__content
     %p= t('.mps_can_help_with')
     %ul.list--bullet
@@ -9,5 +11,5 @@
       %li= t('.immigration')
       %li= t('.school_closures')
       %li= t('.transport')
-    %p= link_to t('.who_else_can_help'), who_should_i_contact_with_my_issue_path
+    %p= link_to(t('.who_else_can_help'), who_should_i_contact_with_my_issue_path)
   %p= t('.contact_postcode')

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -42,7 +42,9 @@
     - unless @history.nil? || @history[:years].empty?
       .dropdown
         .dropdown__toggle
-          %h3= link_to "#{t('.show_history')}", "#"
+          %h3
+            %a{ href: "#" }
+              = t('.show_history')
         .dropdown__content
           .track
             - unless @history.nil? || @history[:current].empty?

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -4,5 +4,5 @@
     %ol.list--block
       %li
         .list--details
-          %h2= link_to t('constituency_plural').capitalize, places_show_constituencies_path(@place.gss_code)
+          %h2= link_to(t('constituency_plural').capitalize, places_show_constituencies_path(@place.gss_code))
           %p= "#{@place.constituency_count} #{t('constituency_plural').capitalize}"


### PR DESCRIPTION
I've ignored all the files inside */app/views/*hybrid_bills**. I've also followed @mattrayner advise on making all links use the rails standard `link_to()` function for all links except for `<a>` tags that don't link to anything, for which I used standard `<a>` tags instead.

```
// With Links
link_to(template, url)

// Without links
%a{ href: "#" }
  = template
```