### PR TITLE
[WEBDEV-480] Former MPs pages

### DIFF
--- a/app/views/people/_previous_roles.html.haml
+++ b/app/views/people/_previous_roles.html.haml
@@ -1,0 +1,6 @@
+- @history[:years].keys.sort.each do |year|
+  %h2= "#{t('.held_in', years: year)}"
+  %ul.list--block
+    = render 'timeline_roles', timeline_roles: @history[:years][year]
+- if @history && @history[:start]
+  %h2= @history[:start].year

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -16,7 +16,7 @@
           = t('.mp_for')
           = link_to(@current_incumbency.constituency.name, constituency_path(@current_incumbency.constituency.graph_id))
       - else
-        %p
+        %p.lead
           = current_party_details if current_party_details
           = @person.statuses[:house_membership_status].join(' and ')
 
@@ -39,7 +39,7 @@
     - if @current_roles
       = render 'current_roles', current_roles: @current_roles
 
-    - unless @history.nil? || @history[:years].empty?
+    - if @history && @history[:current].any?
       .dropdown
         .dropdown__toggle
           %h3
@@ -47,15 +47,14 @@
               = t('.show_history')
         .dropdown__content
           .track
-            - unless @history.nil? || @history[:current].empty?
-              %h2= "#{t('.held_currently')}"
-              %ul.list--block
-                = render 'timeline_roles', timeline_roles: @history[:current]
-            - @history[:years].keys.sort.each do |year|
-              %h2= "#{t('.held_in')} #{year} #{t('.years')}"
-              %ul.list--block
-                = render 'timeline_roles', timeline_roles: @history[:years][year]
-            - if @history && @history[:start]
-              %h2= @history[:start].year
+            %h2= "#{t('.held_currently')}"
+            %ul.list--block
+              = render 'timeline_roles', timeline_roles: @history[:current]
+            = render 'previous_roles'
+    - elsif @history && @history[:current].empty?
+      .container
+        .track
+          = render 'previous_roles'
+
 
 = render 'related_links'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,7 +210,6 @@ en:
       election_history: 'election history'
       roles: 'roles'
       held_currently: 'Held currently'
-      held_in: 'Held in the last'
       show_history: 'Show history'
       years: 'years'
       check_mp: 'Check if %{name} is your MP'
@@ -240,8 +239,8 @@ en:
       government_role: 'government role'
       opposition_role: 'opposition role'
       held_currently: 'Held currently'
-      held_in: 'Held in the last'
-      years: 'years'
+    previous_roles:
+      held_in: "Held in the last %{years} years"
     current_roles:
       mp_for: 'MP for'
       parliamentary_role: 'parliamentary role'


### PR DESCRIPTION
* removed dropdown on former mp pages so role history is always expanded
* Increased size of 'Former mp' heading
* extracted previous_roles logic to partial
* Added previous_roles to en.yml