### PR TITLE
Rename Concept Variables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.21.1)
       parallel
-    parliament-grom-decorators (0.16.3)
+    parliament-grom-decorators (0.16.4)
     parliament-ntriple (0.2.1)
       grom (~> 0.5)
     parliament-routes (0.5.4)

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -13,8 +13,7 @@ class ConceptsController < ApplicationController
     raise ActionController::RoutingError, 'Concept Not Found' unless @concept
 
     # Returns array of Concept Grom::Nodes
-    @parent_concepts = @concept.parent_concepts.sort_by(&:name)
-    @child_concepts = @concept.child_concepts.sort_by(&:name)
+    @narrower_concepts = @concept.narrower_concepts.sort_by(&:name)
     @concept_articles = @concept.tagged_articles.sort_by(&:article_title)
 
   end

--- a/app/views/concepts/show.html.haml
+++ b/app/views/concepts/show.html.haml
@@ -12,8 +12,8 @@
         - @concept_articles.each do |article|
           %li= link_to(article.article_title, article_path(article.graph_id))
 
-    - if @child_concepts.any?
+    - if @narrower_concepts.any?
       %h2= "Other topics in this section"
       %ul.list
-        - @child_concepts.each do |concept|
+        - @narrower_concepts.each do |concept|
           %li= link_to(concept.name, concept_path(concept.graph_id))


### PR DESCRIPTION
* Update parliament-grom-decorators gem with new decorator method names
* Rename @parent_concepts to @broader_concepts in line with common language
* Rename @child_concepts to @narrower_concepts in line with common language
* Update views to use new variables