### PR TITLE
[GTP-191] GTP Navigation/iteration of GTP pages

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -12,7 +12,6 @@ class ArticlesController < ApplicationController
     @article = articles.find { |article| article.graph_id == params[:article_id] }
     raise ActionController::RoutingError, 'Article Not Found' unless @article
 
-    @related_articles = @article.related_articles
     @collections = @article.collections
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -2,7 +2,7 @@ class CollectionsController < ApplicationController
   before_action :data_check, :build_request, :disable_top_navigation
 
   ROUTE_MAP = {
-    show:  proc { |params| Parliament::Utils::Helpers::ParliamentHelper.parliament_request.collection_by_id.set_url_params({ collection_id: params[:collection_id] }) }
+    show: proc { |params| Parliament::Utils::Helpers::ParliamentHelper.parliament_request.collection_by_id.set_url_params({ collection_id: params[:collection_id] }) }
   }.freeze
 
   def show

--- a/app/controllers/concerns/markdown_helper.rb
+++ b/app/controllers/concerns/markdown_helper.rb
@@ -4,6 +4,7 @@ module MarkdownHelper
   # @return template [String] Template as HTML
   def self.markdown(template)
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, tables: true)
-    markdown.render(template)
+    html = markdown.render(ActionController::Base.helpers.sanitize(template))
+    ActionController::Base.helpers.sanitize(html).html_safe
   end
 end

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,27 +1,31 @@
-.container.flex--2__2-1
-  %article{ tabindex: '0', id: 'content' }
-    %header
-      %h1= sanitize @article.title
-      = MarkdownHelper.markdown(sanitize @article.article_summary).html_safe
+.container
+  .article--wrapper
+    %article{ id: 'content', tabindex: '0' }
+      %header
+        - if @collections.any?
+          = render partial: 'collections/delimited_links', locals: { collections: @collections }
 
-    %div{ role: 'main' }
-      = MarkdownHelper.markdown(sanitize @article.article_body).html_safe
+        %h1= title(sanitize(@article.title))
+        = MarkdownHelper.markdown(@article.article_summary)
 
-  %aside
-    - if @related_articles.any?
-      .block
-        %h2= t('.related_articles')
-        %ul.list--pipe
-          - @related_articles.each do |article|
-            %li
-              .list--details
-                = link_to(sanitize(article.article_title), article_path(article.graph_id))
+      %div{ role: 'main' }
+        = MarkdownHelper.markdown(@article.article_body)
 
-    - if @collections.any?
-      .block
-        %h2= t('.collection_articles')
-        %ul.list--pipe
-          - @collections.each do |collection|
-            %li
-              .list--details
-                = link_to(sanitize(collection.name), collection_path(collection.graph_id))
+      - if @collections.any?
+        %footer
+          %h2= t('.up_to')
+          = render partial: 'collections/delimited_links', locals: { collections: @collections }
+
+    %aside
+      - @collections.each do |collection|
+        %h2= sanitize(collection.name)
+        .block
+          %ul.list--pipe
+            - collection.articles.each do |article|
+              %li
+                .list--details
+                  = link_to(sanitize(article.article_title), article_path(article.graph_id))
+            - collection.subcollections.each do |subcollection|
+              %li
+                .list--details
+                  = link_to(sanitize(subcollection.name), collection_path(subcollection.graph_id))

--- a/app/views/collections/_collection.html.haml
+++ b/app/views/collections/_collection.html.haml
@@ -1,0 +1,29 @@
+.container
+  .article--wrapper
+    %article{ id: 'content', tabindex: '0' }
+      %header
+        - if collection.parents.any?
+          = render partial: "collections/delimited_links", locals: { collections: collection.parents }
+
+        %h1= title(sanitize(collection.name))
+
+      %div{ role: 'main' }
+        = MarkdownHelper.markdown(collection.description)
+
+      - if collection.parents.any?
+        %footer
+          %h2= "Up to:"
+          = render partial: "collections/delimited_links", locals: { collections: collection.parents }
+
+    %aside
+      %h2= sanitize(collection.name)
+      .block
+        %ul.list--pipe
+          - collection.articles.each do |article|
+            %li
+              .list--details
+                = link_to(sanitize(article.article_title), article_path(article.graph_id))
+          - collection.subcollections.each do |subcollection|
+            %li
+              .list--details
+                = link_to(sanitize(subcollection.name), collection_path(subcollection.graph_id))

--- a/app/views/collections/_delimited_links.html.haml
+++ b/app/views/collections/_delimited_links.html.haml
@@ -1,0 +1,4 @@
+%p
+  - collections.each_with_index do |collection, index|
+    = link_to(sanitize(collection.name), collection_path(collection.graph_id))
+    = ", " if index != (collections.size - 1)

--- a/app/views/collections/_root_collection.html.haml
+++ b/app/views/collections/_root_collection.html.haml
@@ -1,0 +1,19 @@
+.section--primary
+  .container--offset
+    %h1= title(sanitize(collection.name))
+    = MarkdownHelper.markdown(collection.description)
+
+%section{ id: 'content', tabindex: '0' }
+  .container
+    %h2= t('.in_this_section')
+    %ul.list--block__inline-50
+      - collection.articles.each do |article|
+        %li
+          .list--details
+            %h3= link_to(sanitize(article.article_title), article_path(article.graph_id))
+            = MarkdownHelper.markdown(article.article_summary)
+
+      - collection.subcollections.each do |subcollection|
+        %li
+          .list--details
+            %h3= link_to(sanitize(subcollection.name), collection_path(subcollection.graph_id))

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -1,20 +1,4 @@
-.section--primary
-  .container--offset
-    %h1= sanitize @collection.name
-    %p= MarkdownHelper.markdown(sanitize @collection.description).html_safe
-
-%section#content{ tabindex: '0' }
-  .container
-    %h2= t('.in_this_section')
-    %ul.list--block__inline-50
-      - if @collection.articles.any?
-        - @collection.articles.each do |article|
-          %li
-            .list--details
-              %h3= link_to(sanitize(article.article_title), article_path(article.graph_id))
-
-      - if @collection.subcollections.any?
-        - @collection.subcollections.each do |subcollection|
-          %li
-            .list--details
-              %h3= link_to(sanitize(subcollection.name), collection_path(subcollection.graph_id))
+- if @collection.parents.any?
+  = render 'collection', collection: @collection 
+- else
+  = render 'root_collection', collection: @collection

--- a/app/views/concepts/show.html.haml
+++ b/app/views/concepts/show.html.haml
@@ -1,8 +1,8 @@
 .section--primary
   .container--offset
-    %h1= @concept.name
+    %h1= title(sanitize(@concept.name))
 
-%section#content{ tabindex: "0" }
+%section{ id: 'content', tabindex: "0" }
   .container--offset
     = MarkdownHelper.markdown(@concept.definition)
 
@@ -10,10 +10,10 @@
       %h2= "Articles in this section"
       %ul.list
         - @concept_articles.each do |article|
-          %li= link_to(article.article_title, article_path(article.graph_id))
+          %li= link_to(sanitize(article.article_title), article_path(article.graph_id))
 
     - if @narrower_concepts.any?
       %h2= "Other topics in this section"
       %ul.list
         - @narrower_concepts.each do |concept|
-          %li= link_to(concept.name, concept_path(concept.graph_id))
+          %li= link_to(sanitize(concept.name), concept_path(concept.graph_id))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -718,15 +718,14 @@ en:
   places:
     all_regions: 'All Regions.'
     region_constituencies: 'Find constituencies by region.'
+  # collection translations
+  collections:
+    root_collection:
+      in_this_section: 'In this section'
   # article translations
   articles:
     show:
-      related_articles: 'Related Articles'
-      collection_articles: 'Collections this article belongs to'
-  # collection translations
-  collections:
-    show:
-      in_this_section: 'In this section'
+      up_to: 'Up to:'
   # no content translations
   no_content:
     empty_list:

--- a/spec/fixtures/vcr_cassettes/ArticlesController/_find_parents/with_a_single_root_collection/returns_a_collection.yml
+++ b/spec/fixtures/vcr_cassettes/ArticlesController/_find_parents/with_a_single_root_collection/returns_a_collection.yml
@@ -1,0 +1,227 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/collection_by_id?collection_id=xxxxxxx2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '552'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - "-1"
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Set-Cookie:
+      - ARRAffinity=340e63cd33f60639be9ed6022402f918d196026bdfa43e62ef6564b017e09241;Path=/;HttpOnly;Domain=fixedquery201710091000.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 16 Mar 2018 15:01:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/xxxxxxx2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://example.com/content/schema/Collection> .\r\n<https://id.parliament.uk/xxxxxxx2>
+        <http://example.com/content/schema/collectionName> \"collectionName - 1\"
+        .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionDescription>
+        \"collectionDescription - 1\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasParent>
+        <https://id.parliament.uk/xxxxxxx9> .\r\n<https://id.parliament.uk/xxxxxxx9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionName>
+        \"collectionName - 2\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/KsHS5ZcZ> .\r\n<https://id.parliament.uk/KsHS5ZcZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/KsHS5ZcZ> <http://example.com/content/schema/title>
+        \"title - 1\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/8MHJ9zSp> .\r\n<https://id.parliament.uk/8MHJ9zSp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/8MHJ9zSp> <http://example.com/content/schema/title>
+        \"title - 2\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/oxGevlNF> .\r\n<https://id.parliament.uk/oxGevlNF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/oxGevlNF> <http://example.com/content/schema/title>
+        \"title - 3\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/wSBO4xfC> .\r\n<https://id.parliament.uk/wSBO4xfC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/wSBO4xfC> <http://example.com/content/schema/title>
+        \"title - 4\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/wjtky8tk> .\r\n<https://id.parliament.uk/wjtky8tk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/wjtky8tk> <http://example.com/content/schema/title>
+        \"title - 5\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/9vwTZN0a> .\r\n<https://id.parliament.uk/9vwTZN0a>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/9vwTZN0a> <http://example.com/content/schema/title>
+        \"title - 6\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/Cq5kT5tz> .\r\n<https://id.parliament.uk/Cq5kT5tz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/Cq5kT5tz> <http://example.com/content/schema/title>
+        \"title - 7\" .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionHasArticle>
+        <https://id.parliament.uk/Q8wlHEK2> .\r\n<https://id.parliament.uk/Q8wlHEK2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebArticle>
+        .\r\n<https://id.parliament.uk/Q8wlHEK2> <http://example.com/content/schema/title>
+        \"title - 8\" .\r\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 15:02:33 GMT
+- request:
+    method: get
+    uri: http://localhost:3030/collection_by_id?collection_id=xxxxxxx9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - "-1"
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Set-Cookie:
+      - ARRAffinity=340e63cd33f60639be9ed6022402f918d196026bdfa43e62ef6564b017e09241;Path=/;HttpOnly;Domain=fixedquery201710091000.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 16 Mar 2018 15:01:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/xxxxxxx9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://example.com/content/schema/Collection> .\r\n<https://id.parliament.uk/xxxxxxx9>
+        <http://example.com/content/schema/collectionName> \"collectionName - 2\"
+        .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionDescription>
+        \"collectionDescription - 1\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx2> .\r\n<https://id.parliament.uk/xxxxxxx2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx2> <http://example.com/content/schema/collectionName>
+        \"collectionName - 1\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx7> .\r\n<https://id.parliament.uk/xxxxxxx7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx7> <http://example.com/content/schema/collectionName>
+        \"collectionName - 3\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx8> .\r\n<https://id.parliament.uk/xxxxxxx8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx8> <http://example.com/content/schema/collectionName>
+        \"collectionName - 4\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx6> .\r\n<https://id.parliament.uk/xxxxxxx6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx6> <http://example.com/content/schema/collectionName>
+        \"collectionName - 5\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx5> .\r\n<https://id.parliament.uk/xxxxxxx5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx5> <http://example.com/content/schema/collectionName>
+        \"collectionName - 6\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx4> .\r\n<https://id.parliament.uk/xxxxxxx4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx4> <http://example.com/content/schema/collectionName>
+        \"collectionName - 7\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx3> .\r\n<https://id.parliament.uk/xxxxxxx3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx3> <http://example.com/content/schema/collectionName>
+        \"collectionName - 8\" .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionHasParent>
+        <https://id.parliament.uk/xxxxxxx1> .\r\n<https://id.parliament.uk/xxxxxxx1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx1> <http://example.com/content/schema/collectionName>
+        \"collectionName - 9\" .\r\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 15:02:34 GMT
+- request:
+    method: get
+    uri: http://localhost:3030/collection_by_id?collection_id=xxxxxxx1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - "-1"
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Set-Cookie:
+      - ARRAffinity=340e63cd33f60639be9ed6022402f918d196026bdfa43e62ef6564b017e09241;Path=/;HttpOnly;Domain=fixedquery201710091000.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 16 Mar 2018 15:01:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/xxxxxxx1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://example.com/content/schema/Collection> .\r\n<https://id.parliament.uk/xxxxxxx1>
+        <http://example.com/content/schema/collectionName> \"collectionName - 9\"
+        .\r\n<https://id.parliament.uk/xxxxxxx1> <http://example.com/content/schema/collectionDescription>
+        \"collectionDescription - 1\" .\r\n<https://id.parliament.uk/xxxxxxx1> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxxx9> .\r\n<https://id.parliament.uk/xxxxxxx9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxxx9> <http://example.com/content/schema/collectionName>
+        \"collectionName - 2\" .\r\n<https://id.parliament.uk/xxxxxxx1> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/xxxxxx11> .\r\n<https://id.parliament.uk/xxxxxx11>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/content/schema/Collection>
+        .\r\n<https://id.parliament.uk/xxxxxx11> <http://example.com/content/schema/collectionName>
+        \"collectionName - 3\" .\r\n<https://id.parliament.uk/xxxxxxx1> <http://example.com/content/schema/collectionHasSubcollection>
+        <https://id.parliament.uk/> .\r\n<https://id.parliament.uk/> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://example.com/content/schema/Collection> .\r\n<https://id.parliament.uk/>
+        <http://example.com/content/schema/collectionName> \"collectionName - 4\"
+        .\r\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 15:02:34 GMT
+recorded_with: VCR 4.0.0

--- a/spec/views/articles/show.html.haml_spec.rb
+++ b/spec/views/articles/show.html.haml_spec.rb
@@ -11,14 +11,12 @@ RSpec.describe 'articles/show', vcr: true do
     )
   }
 
-  let!(:related_articles) {
-    assign(:related_articles,
-      [
-        double(:related_articles,
-          article_title: related_article_title_text,
-          graph_id:      '1234abcd'
-        )
-      ]
+  let!(:subcollection) {
+    assign(:subcollection,
+      double(:subcollection,
+        name:        subcollection_name_text,
+        graph_id:    'asdf1234',
+      )
     )
   }
 
@@ -26,13 +24,14 @@ RSpec.describe 'articles/show', vcr: true do
     assign(:collections,
       [
         double(:collections,
-          name:        collection_name_text,
-          description: '**This** is a test description of a Collection.',
-          graph_id:    'h93dvh57',
-          articles:    [
+          name:           collection_name_text,
+          description:    '**This** is a test description of a Collection.',
+          graph_id:       'h93dvh57',
+          subcollections: [subcollection],
+          articles:       [
             double(:article2,
               article_title:    collection_article_title_text,
-              graph_id: 'gj7e0ikd'
+              graph_id:         'gj7e0ikd'
             )
           ]
         )
@@ -40,62 +39,35 @@ RSpec.describe 'articles/show', vcr: true do
     )
   }
 
+  let!(:article_title_text)            { 'This is a test Title.' }
+  let!(:article_body_text)             { '__This__ is an article body' }
+  let!(:collection_name_text)          { 'This is a test Collection.' }
+  let!(:collection_article_title_text) { 'Another article title' }
+  let!(:subcollection_name_text)       { 'Test Subcollection' }
+
   before(:each) do
     render
   end
 
-  context 'valid data' do
-    let!(:article_title_text)            { 'This is a test Title.' }
-    let!(:article_body_text)             { '__This__ is an article body' }
-    let!(:related_article_title_text)    { 'Related article title' }
-    let!(:collection_name_text)          { 'This is a test Collection.' }
-    let!(:collection_article_title_text) { 'Another article title' }
-
+  context 'article' do
     context 'converted to HTML' do
-      context 'article' do
-        it 'will render the article title correctly' do
-          expect(rendered).to match(/<h1>This is a test Title.<\/h1>/)
-        end
-
-        it 'will render the article summary correctly' do
-          expect(rendered).to match(/<h2>This is a test summary.<\/h2>/)
-        end
-
-        it 'will render the article body correctly' do
-          expect(rendered).to match(/<p><strong>This<\/strong> is an article body<\/p>/)
-        end
+      it 'will render the article title correctly' do
+        expect(rendered).to match(/<h1>This is a test Title.<\/h1>/)
       end
 
-      context 'related articles' do
-        it 'displays the correct header' do
-          expect(rendered).to match(/Related Articles/)
-        end
-
-        it 'will render a link to related articles' do
-          expect(rendered).to match(/<a href="\/articles\/1234abcd">Related article title<\/a>/)
-        end
+      it 'will render the article summary correctly' do
+        expect(rendered).to match(/<h2>This is a test summary.<\/h2>/)
       end
 
-      context 'collections' do
-        it 'displays the correct header' do
-          expect(rendered).to match(/Collections this article belongs to/)
-        end
-
-        it 'will render a link to collections that article belongs to' do
-          expect(rendered).to match(/<a href="\/collections\/h93dvh57">This is a test Collection.<\/a>/)
-        end
+      it 'will render the article body correctly' do
+        expect(rendered).to match(/<p><strong>This<\/strong> is an article body<\/p>/)
       end
     end
-  end
 
-  context 'sanitize' do
-    let!(:article_title_text)            { '<script>This is a test Title.</script>' }
-    let!(:article_body_text)             { '<script>__This__ is an article body</script>' }
-    let!(:related_article_title_text)    { '<script>Related article title</script>' }
-    let!(:collection_name_text)          { '<script>This is a test Collection.</script>' }
-    let!(:collection_article_title_text) { '<script>Another article title</script>' }
+    context 'sanitize' do
+      let!(:article_title_text) { '<script>This is a test Title.</script>' }
+      let!(:article_body_text)  { '<script>__This__ is an article body</script>' }
 
-    context 'article' do
       it 'will render the sanitized article title correctly' do
         expect(rendered).to match(/<h1>This is a test Title.<\/h1>/)
       end
@@ -108,16 +80,85 @@ RSpec.describe 'articles/show', vcr: true do
         expect(rendered).to match(/<p><strong>This<\/strong> is an article body<\/p>/)
       end
     end
+  end
 
-    context 'related articles' do
-      it 'will render the sanitized related articles correctly' do
-        expect(rendered).to match(/<a href="\/articles\/1234abcd">Related article title<\/a>/)
+  context 'collections' do
+    context 'converted to HTML' do
+      it 'will render a link to collections that article belongs to' do
+        expect(rendered).to match(/<a href="\/collections\/h93dvh57">This is a test Collection.<\/a>/)
       end
     end
 
-    context 'collections' do
-      it 'will render the collections correctly' do
+    context 'sanitize' do
+      let!(:collection_name_text)          { '<script>This is a test Collection.</script>' }
+      let!(:collection_article_title_text) { '<script>Another article title</script>' }
+
+      it 'will render the sanitized link to collections correctly' do
         expect(rendered).to match(/<a href="\/collections\/h93dvh57">This is a test Collection.<\/a>/)
+      end
+    end
+  end
+
+  context 'collection articles' do
+    context 'converted to HTML' do
+      it 'will render a link to each article in that collection' do
+        expect(rendered).to match(/<a href="\/articles\/gj7e0ikd">Another article title<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:collection_article_title_text) { '<script>Another article title</script>' }
+      it 'will render the sanitized link to each article in that collection' do
+        expect(rendered).to match(/<a href="\/articles\/gj7e0ikd">Another article title<\/a>/)
+      end
+    end
+  end
+
+  context 'collection subcollections' do
+    context 'converted to HTML' do
+      it 'will render a link to each subcollection in that collection' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">Test Subcollection<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:subcollection_name_text) { '<script>Test Subcollection</script>' }
+      it 'will render the sanitized link to each subcollection in that collection' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">Test Subcollection<\/a>/)
+      end
+    end
+  end
+
+  context 'partials' do
+    context 'when collections exist' do
+      it 'will render the collections/delimited_links partial' do
+        expect(response).to render_template(partial: 'collections/_delimited_links')
+      end
+    end
+
+    context 'when collections do not exist' do
+      let!(:collections) {
+        assign(:collections, [])
+      }
+      it 'will not render the collections/delimited_links partial' do
+        expect(response).not_to render_template(partial: 'collections/_delimited_links')
+      end
+    end
+  end
+
+  context 'footer' do
+    context 'when collections exist' do
+      it "will render 'up to' text" do
+        expect(rendered).to match(/Up to/)
+      end
+    end
+
+    context 'when collections do not exist' do
+      let!(:collections) {
+        assign(:collections, [])
+      }
+      it "will not render 'up to' text" do
+        expect(rendered).not_to match(/Up to/)
       end
     end
   end

--- a/spec/views/collections/collection.html.haml_spec.rb
+++ b/spec/views/collections/collection.html.haml_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe 'collections/_collection' do
+  let!(:subcollection) {
+    assign(:subcollection,
+      double(:subcollection,
+        name:        subcollection_name_text,
+        graph_id:    'asdf1234',
+      )
+    )
+  }
+
+  let!(:article) {
+    assign(:article,
+      double(:article,
+        article_title:   article_title_text,
+        article_summary: article_summary_text,
+        graph_id:        'xoxoxox8'
+      )
+    )
+  }
+
+  let!(:collection) {
+    assign(:collection,
+      double(:collection,
+        name:           collection_name_text,
+        description:    collection_description_text,
+        subcollections: [subcollection],
+        articles:       [article],
+        parents:        [parent_collection]
+      )
+    )
+  }
+
+  let!(:parent_collection) {
+    assign(:parent_collection,
+      double(:parent_collection,
+        name:     'Test parent collection',
+        graph_id: 'test1234'
+      )
+    )
+  }
+
+  let!(:collection_name_text) { 'This is a test Collection.' }
+  let!(:collection_description_text) { '**This** is a test description of a Collection.' }
+  let!(:subcollection_name_text) { 'This is a test subcollection name' }
+  let!(:article_title_text) { 'This is a test Title.' }
+  let!(:article_summary_text) { '**This** is an article summary' }
+
+  before(:each) do
+    render partial: "collections/collection", locals: { collection: collection }
+  end
+
+  context 'collection' do
+    context 'converted to HTML' do
+      it 'name will render correctly' do
+        expect(rendered).to match(/<h1>This is a test Collection.<\/h1>/)
+      end
+
+      it 'description will render correctly' do
+        expect(rendered).to match(/<p><strong>This<\/strong> is a test description of a Collection.<\/p>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:collection_name_text) { '<script>This is a test Collection name.</script>' }
+      let!(:collection_description_text) { '<script>__This__ is a Collection description</script>' }
+
+      it 'sanitized name will render correctly' do
+        expect(rendered).to match(/<h1>This is a test Collection name.<\/h1>/)
+      end
+
+      it 'sanitized description will render correctly' do
+        expect(rendered).to match(/<p><strong>This<\/strong> is a Collection description<\/p>/)
+      end
+    end
+  end
+
+  context 'articles' do
+    context 'converted to HTML' do
+      it 'will render articles' do
+        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:article_title_text) { '<script>This is a test Title.</script>' }
+      let!(:article_summary_text) { '<script>__This__ is an article summary</script>' }
+
+      it 'will render the sanitized link to articles' do
+        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
+      end
+    end
+  end
+
+  context 'subcollections' do
+    context 'converted to HTML' do
+      it 'name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:subcollection_name_text) { '<script>This is a test subcollection name.</script>' }
+
+      it 'name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name.<\/a>/)
+      end
+    end
+  end
+
+  context 'partials' do
+    context 'when parent collections exist' do
+      it 'will render the collections/delimited_links partial' do
+        expect(response).to render_template(partial: 'collections/_delimited_links')
+      end
+    end
+
+    context 'when parent collections do not exist' do
+      let!(:collection) {
+        assign(:collection,
+          double(:collection,
+            name:           collection_name_text,
+            description:    collection_description_text,
+            subcollections: [],
+            articles:       [],
+            parents:        []
+          )
+        )
+      }
+
+      it 'will not render the collections/delimited_links partial' do
+        expect(response).not_to render_template(partial: 'collections/_delimited_links')
+      end
+    end
+  end
+
+  context 'footer' do
+    context 'when collections exist' do
+      it "will render 'up to' text" do
+        expect(rendered).to match(/Up to/)
+      end
+    end
+
+    context 'when collections do not exist' do
+      let!(:collection) {
+        assign(:collection,
+          double(:collection,
+            name:           collection_name_text,
+            description:    collection_description_text,
+            subcollections: [],
+            articles:       [],
+            parents:        []
+          )
+        )
+      }
+
+      it "will not render 'up to' text" do
+        expect(rendered).not_to match(/Up to/)
+      end
+    end
+  end
+end

--- a/spec/views/collections/delimited_links.html.haml_spec.rb
+++ b/spec/views/collections/delimited_links.html.haml_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'collections/_delimited_links' do
+  let!(:collections) {
+    assign(:collections,
+      [
+        double(:collection,
+          name:     collection_name_text1,
+          graph_id: 'xxxxxxx1'
+        ),
+        double(:collection,
+          name:     collection_name_text2,
+          graph_id: 'xxxxxxx2'
+        ),
+      ]
+    )
+  }
+
+  let!(:collection_name_text1) { 'This is test collection 1.' }
+  let!(:collection_name_text2) { 'This is test collection 2.' }
+
+  before(:each) do
+    render partial: "collections/delimited_links", locals: { collections: collections }
+  end
+
+  context 'collection' do
+    context 'converted to HTML' do
+      it 'name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/xxxxxxx1">This is test collection 1.<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:collection_name_text1) { '<script>This is test collection 1.</script>' }
+
+      it 'sanitized name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/xxxxxxx1">This is test collection 1.<\/a>/)
+      end
+    end
+  end
+
+  context 'listing collections' do
+    it 'renders comma separated links to each collection' do
+      expect(rendered).to include("<p>\n<a href=\"/collections/xxxxxxx1\">This is test collection 1.</a>\n, \n<a href=\"/collections/xxxxxxx2\">This is test collection 2.</a>\n\n</p>\n")
+    end
+  end
+
+end

--- a/spec/views/collections/root_collection.html.haml_spec.rb
+++ b/spec/views/collections/root_collection.html.haml_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe 'collections/_root_collection' do
+  let!(:subcollection) {
+    assign(:subcollection,
+      double(:subcollection,
+        name:        subcollection_name_text,
+        graph_id:    'asdf1234',
+      )
+    )
+  }
+
+  let!(:article) {
+    assign(:article,
+      double(:article,
+        article_title:   article_title_text,
+        article_summary: article_summary_text,
+        graph_id:        'xoxoxox8'
+      )
+    )
+  }
+
+  let!(:collection) {
+    assign(:collection,
+      double(:collection,
+        name:           collection_name_text,
+        description:    collection_description_text,
+        subcollections: [subcollection],
+        articles:       [article],
+        parents:        []
+      )
+    )
+  }
+
+  let!(:collection_name_text) { 'This is a test Collection.' }
+  let!(:collection_description_text) { '**This** is a test description of a Collection.' }
+  let!(:subcollection_name_text) { 'This is a test subcollection name' }
+  let!(:article_title_text) { 'This is a test Title.' }
+  let!(:article_summary_text) { '**This** is an article summary' }
+
+  before(:each) do
+    render partial: "collections/root_collection", locals: { collection: collection }
+  end
+
+  context 'collection' do
+    context 'converted to HTML' do
+      it 'name will render correctly' do
+        expect(rendered).to match(/<h1>This is a test Collection.<\/h1>/)
+      end
+
+      it 'description will render correctly' do
+        expect(rendered).to match(/<p><strong>This<\/strong> is a test description of a Collection.<\/p>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:collection_name_text) { '<script>This is a test Collection name.</script>' }
+      let!(:collection_description_text) { '<script>__This__ is a Collection description</script>' }
+
+      it 'sanitized name will render correctly' do
+        expect(rendered).to match(/<h1>This is a test Collection name.<\/h1>/)
+      end
+
+      it 'sanitized escription will render correctly' do
+        expect(rendered).to match(/<p><strong>This<\/strong> is a Collection description<\/p>/)
+      end
+    end
+  end
+
+  context 'articles' do
+    context 'converted to HTML' do
+      it 'will render articles' do
+        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:article_title_text) { '<script>This is a test Title.</script>' }
+      let!(:article_summary_text) { '<script>__This__ is an article summary</script>' }
+
+      it 'will render the sanitized link to articles' do
+        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
+      end
+    end
+  end
+
+  context 'subcollection' do
+    context 'converted to HTML' do
+      it 'name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name<\/a>/)
+      end
+    end
+
+    context 'sanitize' do
+      let!(:subcollection_name_text) { '<script>This is a test subcollection name.</script>' }
+
+      it 'name will render correctly' do
+        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name.<\/a>/)
+      end
+    end
+  end
+
+  context 'headings' do
+    it 'displays the correct header for the root collection' do
+      expect(rendered).to match(/In this section/)
+    end
+  end
+
+end

--- a/spec/views/collections/show.html.haml_spec.rb
+++ b/spec/views/collections/show.html.haml_spec.rb
@@ -1,30 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe 'collections/show', vcr: true do
-  let!(:subcollection) {
-    assign(:subcollection,
-      double(:subcollection,
-        name:        subcollection_name_text,
-        graph_id:    'asdf1234'
-      )
-    )
-  }
-  let!(:article) {
-    assign(:article,
-      double(:article,
-        article_title:   article_title_text,
-        graph_id:        'xoxoxox8'
+  let!(:collection) {
+    assign(:collection,
+      double(:collection,
+        name:           'Test collection',
+        description:    'Test collection description',
+        graph_id:       'fghj76kl',
+        parents:        [parent_collection],
+        articles:       [],
+        subcollections: []
       )
     )
   }
 
-  let!(:collection) {
-    assign(:collection,
-      double(:collection,
-        name:           collection_name_text,
-        description:    collection_description_text,
-        subcollections: [subcollection],
-        articles:       [article]
+  let!(:parent_collection) {
+    assign(:parent_collection,
+      double(:parent_collection,
+        name: 'Test Parent',
+        graph_id: 'v6v7b8b8'
       )
     )
   }
@@ -33,68 +27,31 @@ RSpec.describe 'collections/show', vcr: true do
     render
   end
 
-
-  context 'valid data' do
-    let!(:collection_name_text) { 'This is a test Collection.' }
-    let!(:collection_description_text) { '**This** is a test description of a Collection.' }
-    let!(:subcollection_name_text) { 'This is a test subcollection name' }
-    let!(:article_title_text) { 'This is a test Title.' }
-
-    context 'headings' do
-      it 'displays the correct header' do
-        expect(rendered).to match(/In this section/)
+  context 'partials' do
+    context 'when a collection has at least one parent collection' do
+      it "renders the 'collection' partial" do
+        expect(response).to render_template(partial: 'collections/_collection')
       end
     end
 
-    context 'collection' do
-      it 'name will render correctly' do
-        expect(rendered).to match(/<h1>This is a test Collection.<\/h1>/)
-      end
+    context 'when a collection is the root (has no parents)' do
+      let!(:collection) {
+        assign(:collection,
+          double(:collection,
+            name:          'Test collection',
+            description:   'Test collection description',
+            graph_id:      'fghj76kl',
+            parents:       [],
+            articles:      [],
+            subcollections: []
+          )
+        )
+      }
 
-      it 'description will render correctly' do
-        expect(rendered).to match(/<p><strong>This<\/strong> is a test description of a Collection.<\/p>/)
-      end
-    end
-
-    context 'subcollection' do
-      it 'name will render correctly' do
-        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name<\/a>/)
-      end
-    end
-
-    context 'articles' do
-      it 'will render articles' do
-        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
+      it "renders the 'root_collection' partial" do
+        expect(response).to render_template(partial: 'collections/_root_collection')
       end
     end
   end
 
-  context 'sanitize' do
-    let!(:collection_name_text) { '<script>This is a test Collection name.</script>' }
-    let!(:collection_description_text) { '<script>__This__ is a Collection descrpition</script>' }
-    let!(:subcollection_name_text) { '<script>This is a test subcollection name.</script>' }
-    let!(:article_title_text) { '<script>This is a test Title.</script>' }
-
-    context 'collection' do
-      it 'name will render correctly' do
-        expect(rendered).to match(/<h1>This is a test Collection name.<\/h1>/)
-      end
-
-      it 'description will render correctly' do
-        expect(rendered).to match(/<p><strong>This<\/strong> is a Collection descrpition<\/p>/)
-      end
-    end
-
-    context 'subcollection' do
-      it 'name will render correctly' do
-        expect(rendered).to match(/<a href="\/collections\/asdf1234">This is a test subcollection name.<\/a>/)
-      end
-    end
-
-    context 'articles' do
-      it 'will render articles' do
-        expect(rendered).to match(/<a href="\/articles\/xoxoxox8">This is a test Title.<\/a>/)
-      end
-    end
-  end
 end


### PR DESCRIPTION
* Remove @related_articles variable, replacing with @collection.articles
* Amend articles/show view to show other articles in all collections an article belongs to, instead of related articles
* Update articles/show tests
* Update collections/show tests
* Update HTML on articles/show view
* Update articles/show translations in en.yml
* Update collections/show translations in en.yml
* Created collections/show partials for a root and non-root collection, and for delimited collection rendering
* Updated collections/show view to conditionally render root/non-root partials depending on whether collection has parents
* Add page title to title tags in articles/show and collections/show views
* Update pugin to 1.6.20
* Sanitize concepts/show page