### PR TITLE
[Fix] Correct tests to compare full month name to rendered views

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,9 +442,7 @@ en:
   # global time format translations
   time:
     formats:
-      default: '%-d %b %Y'
-  date:
-    abbr_month_names: ['', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      default: '%-d %B %Y'
   # global error message translations
   error:
     no_constituency: "we couldn't find the postcode you entered."

--- a/spec/views/constituencies/_constituency.html.haml_spec.rb
+++ b/spec/views/constituencies/_constituency.html.haml_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'constituencies/_constituency', vcr: true do
       end
 
       it 'will not render start date' do
-        expect(rendered).not_to match("from #{(Time.zone.now - 1.month).strftime('%-e %b %Y')}")
+        expect(rendered).not_to match("from #{(Time.zone.now - 1.month).strftime('%-d %B %Y')}")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe 'constituencies/_constituency', vcr: true do
       end
 
       it 'will render start date' do
-        expect(rendered).to match("from #{(Time.zone.now - 1.month).strftime('%-e %b %Y')}")
+        expect(rendered).to match("from #{(Time.zone.now - 1.month).strftime('%-d %B %Y')}")
       end
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe 'constituencies/_constituency', vcr: true do
       end
 
       it 'will render the end date' do
-        expect(rendered).to match("to #{(Time.zone.now - 1.day).strftime('%-e %b %Y')}")
+        expect(rendered).to match("to #{(Time.zone.now - 1.day).strftime('%-d %B %Y')}")
       end
     end
   end
@@ -102,13 +102,13 @@ RSpec.describe 'constituencies/_constituency', vcr: true do
           end
 
           it 'will not render current incumbency start date' do
-            expect(rendered).not_to match("#{(Time.zone.now - 1.month).strftime('%-e %b %Y')} to present")
+            expect(rendered).not_to match("#{(Time.zone.now - 1.month).strftime('%-d %B %Y')} to present")
           end
         end
 
         context 'is not nil' do
           before do
-            assign(:current_incumbency, double(:current_incumbency, date_range: "#{(Time.zone.now - 1.month).strftime('%-e %b %Y')} to present", member: double(:member, display_name: 'Test Display Name', graph_id: '7TX8ySd4')))
+            assign(:current_incumbency, double(:current_incumbency, date_range: "#{(Time.zone.now - 1.month).strftime('%-d %B %Y')} to present", member: double(:member, display_name: 'Test Display Name', graph_id: '7TX8ySd4')))
             render
           end
         end
@@ -146,8 +146,8 @@ RSpec.describe 'constituencies/_constituency', vcr: true do
 
     it 'will list constituency' do
       expect(rendered).to match(/Constituency/)
-      expect(rendered).to match("from #{(Time.zone.now - 1.month).strftime('%-e %b %Y')}")
-      expect(rendered).to match("to #{(Time.now - 1.day).strftime('%-e %b %Y')}")
+      expect(rendered).to match("from #{(Time.zone.now - 1.month).strftime('%-d %B %Y')}")
+      expect(rendered).to match("to #{(Time.now - 1.day).strftime('%-d %B %Y')}")
     end
   end
 


### PR DESCRIPTION
* Update _constituency partial tests
* Update translation file to defaultly use full month names when formatting time