### PR TITLE
[PET-148] Sanitize @question.heading

### DIFF
--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -1,7 +1,7 @@
 .section--primary
   .container
     %h1
-      %span= title(@question.heading)
+      %span= title(sanitize @question.heading)
       - if @answering_body
         %span.context= "#{t('.for').capitalize} #{@answering_body.name}"
 


### PR DESCRIPTION
On this page https://beta.parliament.uk/questions/FmzGMjBZ, the person's name is formatting the name `Peers' Interests` as `Peers&#39; Interests` in the title tag.