### PR TITLE
TIFF downloads

### DIFF
--- a/app/views/media/show.html.haml
+++ b/app/views/media/show.html.haml
@@ -21,7 +21,8 @@
 
         %p= t('.license_context', link: link_to(t('.license_context_link'), 'https://creativecommons.org/licenses/by/3.0/')).html_safe
 
-        = link_to(t('.download_jpeg').capitalize + ' ' + t('.download_res_original'), "#{ENV['IMAGE_SERVICE_URL']}/#{@image.graph_id}.jpeg?download=true", class: 'btn--primary', 'aria-label': t('.download_original').capitalize + " portrait of #{@person.display_name} " + t('.alt_text_wide_original'), download: '' )
+        = link_to(t('.download_original').capitalize + ' ' + t('.download_res_original'), "#{ENV['IMAGE_SERVICE_URL']}/#{@image.graph_id}.tif?download=true", class: 'btn--primary', 'aria-label': t('.download_original').capitalize + " portrait of #{@person.display_name} " + t('.alt_text_wide_original'), download: '' )
+        = link_to(t('.download_jpeg').capitalize + ' ' + t('.download_res_original'), "#{ENV['IMAGE_SERVICE_URL']}/#{@image.graph_id}.jpeg?download=true", class: 'btn--primary', 'aria-label': t('.download_jpeg').capitalize + " portrait of #{@person.display_name} " + t('.alt_text_wide_original'), download: '' )
 
       - else
         .highlight--box.highlight--caution__soft


### PR DESCRIPTION
True originals are now available from the Photo Service.
This adds a download button (using existing localisation strings) to the media page.